### PR TITLE
Disable C6 after resume from suspend and hibernate.

### DIFF
--- a/disable-c6.service.template
+++ b/disable-c6.service.template
@@ -1,7 +1,7 @@
 [Unit]
 Description=Ryzen Disable C6
 DefaultDependencies=no
-After=sysinit.target local-fs.target
+After=sysinit.target local-fs.target suspend.target hibernate.target
 Before=basic.target
 
 [Service]
@@ -9,4 +9,5 @@ Type=oneshot
 ExecStart={{PREFIX}}/bin/zenstates.py --c6-disable
 
 [Install]
-WantedBy=basic.target
+WantedBy=basic.target suspend.target hibernate.target
+


### PR DESCRIPTION
Issue #1 should be resolved by this change. With the previous comment I had missed that hibernate was using a different target. I tested this change on my Debian system multiple times now to ensure I don't miss something again. 

Here is the output from journalctl after one of my last tests to hibernate:

    Nov 30 19:30:59 pixie systemd[1]: Stopped target Hibernate.
    Nov 30 19:30:59 pixie systemd[1]: Starting Ryzen Disable C6...
    [...]
    Nov 30 19:30:59 pixie zenstates.py[25858]: Disabling C6 state
    Nov 30 19:30:59 pixie systemd[1]: Started Ryzen Disable C6.

I find the same entries when testing suspend (and can confirm with `zenstates.py -l`) that the C6 states are disabled.