### PR TITLE
fix ExecStart error in ubuntu

### DIFF
--- a/disable-c6.service.template
+++ b/disable-c6.service.template
@@ -6,7 +6,7 @@ Before=basic.target
 
 [Service]
 Type=oneshot
-ExecStart={{PREFIX}}/bin/zenstates.py --c6-disable
+ExecStart=python3 {{PREFIX}}/bin/zenstates.py --c6-disable
 
 [Install]
 WantedBy=basic.target suspend.target hibernate.target


### PR DESCRIPTION
Specify python3 as the interpreter of [zenstates.py](https://github.com/r4m0n/ZenStates-Linux#zenstatespy)